### PR TITLE
Bug | Remove Demo Credentials From Login Page

### DIFF
--- a/views/site/login.php
+++ b/views/site/login.php
@@ -1,9 +1,12 @@
 <?php
 
 /** @var yii\web\View $this */
+
 /** @var yii\bootstrap5\ActiveForm $form */
 
-/** @var app\models\LoginForm $model */
+/**
+ * @var app\models\LoginForm $model
+ */
 
 use yii\bootstrap5\ActiveForm;
 use yii\bootstrap5\Html;
@@ -44,11 +47,6 @@ $this->params['breadcrumbs'][] = $this->title;
             </div>
 
             <?php ActiveForm::end(); ?>
-
-            <div style="color:#999;">
-                You may login with <strong>admin/admin</strong> or <strong>demo/demo</strong>.<br>
-                To modify the username/password, please check out the code <code>app\models\User::$users</code>.
-            </div>
 
         </div>
     </div>


### PR DESCRIPTION
- Problem: The login page displayed demo credentials, which is a security and UX concern.
- Fix: Removed the demo credentials hint from views/site/login.php.
- Scope: UI-only; single file change.
- Risk: Low.
- Verification:
   - Logout and visit /site/login
   -  Confirm the demo credentials hint is no longer visible
   - Login flow still works as before
<img width="770" height="696" alt="Screenshot from 2025-08-20 19-42-06" src="https://github.com/user-attachments/assets/e155ede9-f936-40fb-996e-2bd85b8ae339" />
