### PR TITLE
Bug | Remove Todos Navbar Link (404)

### DIFF
--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -40,7 +40,6 @@ $this->registerLinkTag(['rel' => 'icon', 'type' => 'image/x-icon', 'href' => Yii
         'options' => ['class' => 'navbar-nav'],
         'items' => [
             ['label' => 'Home', 'url' => ['/site/index']],
-            ['label' => 'Todos', 'url' => ['/todo/index'], 'visible' => !Yii::$app->user->isGuest], // will work after CRUD
             ['label' => 'Signup', 'url' => ['/site/signup'], 'visible' => Yii::$app->user->isGuest],
             ['label' => 'Login', 'url' => ['/site/login'], 'visible' => Yii::$app->user->isGuest],
             Yii::$app->user->isGuest ? '' : '<li class="nav-item">'


### PR DESCRIPTION

<img width="775" height="737" alt="Screenshot from 2025-08-20 20-33-44" src="https://github.com/user-attachments/assets/d990aa4f-0dbf-46cd-9c5b-47a2b124c002" />

- Problem: Navbar contained a “Todos” link pointing to a non-existent route, causing a 404.
- Fix: Removed the “Todos” menu item from views/layouts/main.php. Todos are shown on Home.
- Scope: Single-file UI change.
- Risk: Low.
- Verification:
  - Log in and check the navbar: “Todos” link is no longer present.
  - Home still lists and manages todos as expected.


<img width="784" height="554" alt="Screenshot from 2025-08-20 20-49-11" src="https://github.com/user-attachments/assets/a45d9e5e-65f7-4735-8e90-58ffa835af8d" />
