### PR TITLE
Feature | Board columns with per‑todo timer

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -10,7 +10,7 @@ $config = [
     'bootstrap' => ['log'],
     'aliases' => [
         '@bower' => '@vendor/bower-asset',
-        '@npm'   => '@vendor/npm-asset',
+        '@npm' => '@vendor/npm-asset',
     ],
     'components' => [
         'request' => [
@@ -43,14 +43,13 @@ $config = [
             ],
         ],
         'db' => $db,
-        /*
         'urlManager' => [
             'enablePrettyUrl' => true,
             'showScriptName' => false,
             'rules' => [
+                'site/delete/<id:\d+>' => 'site/delete',
             ],
         ],
-        */
     ],
     'params' => $params,
 ];
@@ -61,14 +60,14 @@ if (YII_ENV_DEV) {
     $config['modules']['debug'] = [
         'class' => 'yii\debug\Module',
         // uncomment the following to add your IP if you are not connecting from localhost.
-        //'allowedIPs' => ['127.0.0.1', '::1'],
+        // 'allowedIPs' => ['127.0.0.1', '::1'],
     ];
 
     $config['bootstrap'][] = 'gii';
     $config['modules']['gii'] = [
         'class' => 'yii\gii\Module',
         // uncomment the following to add your IP if you are not connecting from localhost.
-        //'allowedIPs' => ['127.0.0.1', '::1'],
+        // 'allowedIPs' => ['127.0.0.1', '::1'],
     ];
 }
 

--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -22,7 +22,7 @@ class SiteController extends Controller
         return [
             'access' => [
                 'class' => AccessControl::class,
-                'only' => ['index', 'toggle-todo', 'update-todo', 'logout'],
+                'only' => ['index', 'toggle-todo', 'update-todo', 'logout', 'delete'],
                 'rules' => [
                     [
                         'allow' => true,
@@ -38,6 +38,7 @@ class SiteController extends Controller
                     'update-todo' => ['post'],
                     'start-todo' => ['post'],
                     'complete-todo' => ['post'],
+                    'delete' => ['post'],
                 ],
             ],
         ];
@@ -174,6 +175,23 @@ class SiteController extends Controller
                 Yii::$app->session->setFlash('error', 'Failed to complete Todo.');
             }
         }
+        return $this->redirect(['site/index']);
+    }
+
+    public function actionDelete($id)
+    {
+        $todo = Todo::find()->forUser(Yii::$app->user->id)->byId((int) $id)->one();
+
+        if (!$todo) {
+            Yii::$app->session->setFlash('error', 'Todo does not exists.');
+            return $this->redirect(['site/index']);
+        }
+        if ($todo->delete() === false) {
+            Yii::$app->session->setFlash('error', 'Failed to delete Todo.');
+        } else {
+            Yii::$app->session->setFlash('success', 'Todo deleted.');
+        }
+
         return $this->redirect(['site/index']);
     }
 

--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -22,7 +22,7 @@ class SiteController extends Controller
         return [
             'access' => [
                 'class' => AccessControl::class,
-                'only' => ['index', 'toggle-todo', 'update-todo', 'logout', 'delete'],
+                'only' => ['index', 'toggle-todo', 'update-todo', 'logout', 'delete', 'move-todo'],
                 'rules' => [
                     [
                         'allow' => true,
@@ -39,6 +39,7 @@ class SiteController extends Controller
                     'start-todo' => ['post'],
                     'complete-todo' => ['post'],
                     'delete' => ['post'],
+                    'move-todo' => ['post'],
                 ],
             ],
         ];
@@ -193,6 +194,55 @@ class SiteController extends Controller
         }
 
         return $this->redirect(['site/index']);
+    }
+
+    public function actionMoveTodo()
+    {
+        Yii::$app->response->format = Response::FORMAT_JSON;
+
+        $id = (int) Yii::$app->request->post('id');
+        $targetStatus = (int) Yii::$app->request->post('status');
+
+        $validStatuses = [Todo::STATUS_PENDING, Todo::STATUS_IN_PROGRESS, Todo::STATUS_DONE];
+        if (!in_array($targetStatus, $validStatuses, true)) {
+            return ['ok' => false, 'message' => 'Invalid status'];
+        }
+
+        $todo = Todo::find()->forUser(Yii::$app->user->id)->byId($id)->one();
+        if (!$todo) {
+            return ['ok' => false, 'message' => 'Todo not found'];
+        }
+
+        // Business rules: prevent invalid status transitions
+        $currentStatus = (int) $todo->status;
+        if ($currentStatus === Todo::STATUS_IN_PROGRESS && $targetStatus === Todo::STATUS_PENDING) {
+            return ['ok' => false, 'message' => 'Cannot move from In Progress back to Backlog'];
+        }
+        if ($currentStatus === Todo::STATUS_DONE && in_array($targetStatus, [Todo::STATUS_PENDING, Todo::STATUS_IN_PROGRESS], true)) {
+            return ['ok' => false, 'message' => 'Cannot move from Completed back to previous statuses'];
+        }
+        if ($currentStatus === Todo::STATUS_PENDING && $targetStatus === Todo::STATUS_DONE) {
+            return ['ok' => false, 'message' => 'Cannot skip In Progress status'];
+        }
+
+        $todo->status = $targetStatus;
+        if ($targetStatus === Todo::STATUS_IN_PROGRESS && $todo->started_at == null) {
+            $todo->started_at = time();
+            $todo->completed_at = null;
+        }
+        if ($targetStatus === Todo::STATUS_DONE && $todo->completed_at == null) {
+            $todo->completed_at = time();
+        }
+        if ($targetStatus === Todo::STATUS_PENDING) {
+            // Keep started_at if already set; clear completion when moving out of Done
+            $todo->completed_at = null;
+        }
+
+        if ($todo->save(false)) {
+            return ['ok' => true];
+        }
+
+        return ['ok' => false, 'message' => 'Failed to save'];
     }
 
     public function actionSignup()

--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -36,6 +36,8 @@ class SiteController extends Controller
                     'logout' => ['post'],
                     'toggle-todo' => ['post'],
                     'update-todo' => ['post'],
+                    'start-todo' => ['post'],
+                    'complete-todo' => ['post'],
                 ],
             ],
         ];
@@ -79,10 +81,16 @@ class SiteController extends Controller
         }
 
         $todos = Todo::find()->forUser(Yii::$app->user->id)->recent()->all();
+        $backlog = Todo::find()->forUser(Yii::$app->user->id)->pending()->recent()->all();
+        $inProgress = Todo::find()->forUser(Yii::$app->user->id)->inProgress()->recent()->all();
+        $completed = Todo::find()->forUser(Yii::$app->user->id)->done()->recent()->all();
 
         return $this->render('index', [
             'model' => $todo,
             'todos' => $todos,
+            'backlog' => $backlog,
+            'inProgress' => $inProgress,
+            'completed' => $completed,
         ]);
     }
 
@@ -124,6 +132,48 @@ class SiteController extends Controller
             Yii::$app->session->setFlash('error', 'Unable to update todo.');
         }
 
+        return $this->redirect(['site/index']);
+    }
+
+    public function actionStartTodo($id)
+    {
+        $todo = Todo::find()->forUser(Yii::$app->user->id)->byId((int) $id)->one();
+        if (!$todo) {
+            Yii::$app->session->setFlash('error', 'Todo does not exists.');
+            return $this->redirect(['site/index']);
+        }
+        if ((int) $todo->status === Todo::STATUS_PENDING) {
+            $todo->status = Todo::STATUS_IN_PROGRESS;
+            if ($todo->started_at == null) {
+                $todo->started_at == time();
+            }
+            if ($todo->save(false)) {
+                Yii::$app->session->setFlash('success', 'Todo started.');
+            } else {
+                Yii::$app->session->setFlash('error', 'Failed to start Todo.');
+            }
+        }
+        return $this->redirect['site/index'];
+    }
+
+    public function actionCompleteTodo($id)
+    {
+        $todo = Todo::find()->forUser(Yii::$app->user->id)->byId((int) $id)->one();
+        if (!todo) {
+            Yii::$app->session->setFlash('error', 'Todo does not exists.');
+            return $this->redirect(['site/index']);
+        }
+        if ((int) $todo->status != Todo::STATUS_DONE) {
+            $todo->status = Todo::STATUS_DONE;
+            if ($todo->completed_at == null) {
+                $todo->completd_at == time();
+            }
+            if ($todo->save(false)) {
+                Yii::$app->session->setFlash('success', 'Todo completed.');
+            } else {
+                Yii::$app->session->setFlash('error', 'Failed to complete Todo.');
+            }
+        }
         return $this->redirect(['site/index']);
     }
 

--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -145,7 +145,7 @@ class SiteController extends Controller
         if ((int) $todo->status === Todo::STATUS_PENDING) {
             $todo->status = Todo::STATUS_IN_PROGRESS;
             if ($todo->started_at == null) {
-                $todo->started_at == time();
+                $todo->started_at = time();
             }
             if ($todo->save(false)) {
                 Yii::$app->session->setFlash('success', 'Todo started.');
@@ -153,20 +153,20 @@ class SiteController extends Controller
                 Yii::$app->session->setFlash('error', 'Failed to start Todo.');
             }
         }
-        return $this->redirect['site/index'];
+        return $this->redirect(['site/index']);
     }
 
     public function actionCompleteTodo($id)
     {
         $todo = Todo::find()->forUser(Yii::$app->user->id)->byId((int) $id)->one();
-        if (!todo) {
+        if (!$todo) {
             Yii::$app->session->setFlash('error', 'Todo does not exists.');
             return $this->redirect(['site/index']);
         }
         if ((int) $todo->status != Todo::STATUS_DONE) {
             $todo->status = Todo::STATUS_DONE;
             if ($todo->completed_at == null) {
-                $todo->completd_at == time();
+                $todo->completed_at = time();
             }
             if ($todo->save(false)) {
                 Yii::$app->session->setFlash('success', 'Todo completed.');

--- a/migrations/m250821_085217_add_started_and_completed_at_to_todo_table.php
+++ b/migrations/m250821_085217_add_started_and_completed_at_to_todo_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use yii\db\Migration;
+
+class m250821_085217_add_started_and_completed_at_to_todo_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{%todo}}', 'started_at', $this->integer()->null());
+        $this->addColumn('{{%todo}}', 'completed_at', $this->integer()->null());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{%todo}}', 'started_at');
+        $this->dropColumn('{{%todo}}', 'completed_at');
+    }
+
+    /*
+     * // Use up()/down() to run migration code without a transaction.
+     * public function up()
+     * {
+     *
+     * }
+     *
+     * public function down()
+     * {
+     *     echo "m250821_085217_add_started_and_completed_at_to_todo_table cannot be reverted.\n";
+     *
+     *     return false;
+     * }
+     */
+}

--- a/models/Todo.php
+++ b/models/Todo.php
@@ -9,11 +9,13 @@ class Todo extends ActiveRecord
 {
     const STATUS_PENDING = 0;
     const STATUS_DONE = 1;
+    const STATUS_IN_PROGRESS = 2;
 
     public static function getStatusList()
     {
         return [
             self::STATUS_PENDING => 'Pending',
+            self::STATUS_IN_PROGRESS => 'In Progress',
             self::STATUS_DONE => 'Done',
         ];
     }
@@ -43,6 +45,7 @@ class Todo extends ActiveRecord
             [['description'], 'string'],
             [['user_id', 'status', 'created_at', 'updated_at'], 'integer'],
             [['title'], 'string', 'max' => 255],
+            [['started_at', 'completed_at'], 'integer'],
         ];
     }
 
@@ -54,9 +57,17 @@ class Todo extends ActiveRecord
         ];
     }
 
+    public function getElapsedSeconds()
+    {
+        if ($this->started_at == null) {
+            return null;
+        }
+        $end = $this->completed_at ?? time();
+        return max(0, $end - (int) $this->started_at);
+    }
+
     public static function find()
     {
         return new TodoQuery(get_called_class());
     }
 }
-

--- a/models/TodoQuery.php
+++ b/models/TodoQuery.php
@@ -30,4 +30,9 @@ class TodoQuery extends ActiveQuery
     {
         return $this->andWhere(['id' => $id]);
     }
+
+    public function inProgress(): self
+    {
+        return $this->andWhere(['status' => Todo::STATUS_IN_PROGRESS]);
+    }
 }

--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -49,6 +49,15 @@ $this->registerLinkTag(['rel' => 'icon', 'type' => 'image/x-icon', 'href' => Yii
                 . '</li>',
         ],
     ]);
+    echo Html::tag('div',
+        Html::button('Toggle theme', [
+            'id' => 'theme-toggle',
+            'class' => 'btn btn-outline-light btn-sm',
+            'title' => 'Switch light/dark',
+            'type' => 'button',
+        ]),
+        ['class' => 'ms-auto']
+    );
     NavBar::end();
     ?>
 </header>
@@ -73,6 +82,37 @@ $this->registerLinkTag(['rel' => 'icon', 'type' => 'image/x-icon', 'href' => Yii
 </footer>
 
 <?php $this->endBody() ?>
+<?php
+$this->registerJs(<<<'JS'
+  (function(){
+    var storageKey = 'todoapp-theme';
+    var root = document.documentElement;
+    function applyTheme(theme){
+      if(theme === 'dark'){
+        root.setAttribute('data-theme','dark');
+      } else {
+        root.removeAttribute('data-theme');
+      }
+    }
+    var saved = '';
+    try { saved = localStorage.getItem(storageKey) || ''; } catch(e) {}
+    if(!saved){
+      var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      saved = prefersDark ? 'dark' : 'light';
+    }
+    applyTheme(saved);
+    var btn = document.getElementById('theme-toggle');
+    if(btn){
+      btn.addEventListener('click', function(){
+        var current = root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        var next = current === 'dark' ? 'light' : 'dark';
+        applyTheme(next);
+        try { localStorage.setItem(storageKey, next); } catch(e) {}
+      });
+    }
+  })();
+JS);
+?>
 </body>
 </html>
 <?php $this->endPage() ?>

--- a/views/site/index.php
+++ b/views/site/index.php
@@ -42,7 +42,7 @@ $this->title = 'Home';
 <hr>
 
 <div class="row g-4 board-columns">
-  <div class="col-md-4">
+  <div class="col-md-4" data-column-status="0">
     <div class="board-header d-flex justify-content-between align-items-center mb-2">
       <h4 class="mb-0">Backlog</h4>
       <span class="badge rounded-pill bg-secondary"><?= isset($backlog) ? count($backlog) : 0 ?></span>
@@ -51,7 +51,7 @@ $this->title = 'Home';
       <p class="text-muted">No items.</p>
     <?php else:
     foreach ($backlog as $t): ?>
-      <div class="card mb-3 shadow-sm">
+      <div class="card mb-3 shadow-sm" draggable="true" data-todo-id="<?= (int)$t->id ?>">
         <div class="card-body">
           <div class="d-flex justify-content-between">
             <strong><?= \yii\helpers\Html::encode($t->title) ?></strong>
@@ -76,7 +76,7 @@ $this->title = 'Home';
 endif; ?>
   </div>
 
-  <div class="col-md-4">
+  <div class="col-md-4" data-column-status="2">
     <div class="board-header d-flex justify-content-between align-items-center mb-2">
       <h4 class="mb-0">In Progress</h4>
       <span class="badge rounded-pill bg-warning text-dark"><?= isset($inProgress) ? count($inProgress) : 0 ?></span>
@@ -85,7 +85,7 @@ endif; ?>
       <p class="text-muted">No items.</p>
     <?php else:
     foreach ($inProgress as $t): ?>
-      <div class="card mb-3 border-warning shadow-sm">
+      <div class="card mb-3 border-warning shadow-sm" draggable="true" data-todo-id="<?= (int)$t->id ?>">
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center">
             <strong><?= \yii\helpers\Html::encode($t->title) ?></strong>
@@ -115,7 +115,7 @@ endif; ?>
 endif; ?>
   </div>
 
-  <div class="col-md-4">
+  <div class="col-md-4" data-column-status="1">
     <div class="board-header d-flex justify-content-between align-items-center mb-2">
       <h4 class="mb-0">Completed</h4>
       <span class="badge rounded-pill bg-success"><?= isset($completed) ? count($completed) : 0 ?></span>
@@ -124,7 +124,7 @@ endif; ?>
       <p class="text-muted">No items.</p>
     <?php else:
     foreach ($completed as $t): ?>
-      <div class="card mb-3 border-success shadow-sm">
+      <div class="card mb-3 border-success shadow-sm" draggable="true" data-todo-id="<?= (int)$t->id ?>">
         <div class="card-body">
           <strong><?= \yii\helpers\Html::encode($t->title) ?></strong>
           <?php if ($t->description): ?>
@@ -154,6 +154,9 @@ endif; ?>
 </div>
 
 <?php
+// Provide safe URL variables for JS
+$this->registerJsVar('moveTodoUrl', \yii\helpers\Url::to(['site/move-todo']));
+
 $this->registerJs(<<<'JS'
     function formatDuration(totalSeconds){
       totalSeconds = Math.max(0, parseInt(totalSeconds || 0, 10));
@@ -186,6 +189,99 @@ $this->registerJs(<<<'JS'
         el.textContent = "00:00:00"; // not started yet
       }
     });
+    
+    // Drag & Drop move between columns
+    (function(){
+      const cards = document.querySelectorAll('.card[draggable][data-todo-id]');
+      const columns = document.querySelectorAll('[data-column-status]');
+      let draggedId = null;
+
+      cards.forEach(card => {
+        card.addEventListener('dragstart', e => {
+          draggedId = card.getAttribute('data-todo-id');
+          e.dataTransfer.setData('text/plain', draggedId);
+          e.dataTransfer.effectAllowed = 'move';
+          card.classList.add('dragging');
+        });
+        card.addEventListener('dragend', () => {
+          draggedId = null;
+          card.classList.remove('dragging');
+        });
+      });
+
+      columns.forEach(col => {
+        col.addEventListener('dragover', e => {
+          if (!draggedId) return;
+          
+          // Check if this move is allowed
+          const draggedCard = document.querySelector('.card[draggable][data-todo-id="'+draggedId+'"]');
+          if (!draggedCard) return;
+          
+          const currentCol = draggedCard.closest('[data-column-status]');
+          const currentStatus = parseInt(currentCol.getAttribute('data-column-status'), 10);
+          const targetStatus = parseInt(col.getAttribute('data-column-status'), 10);
+          
+          // Apply business rules
+          let isAllowed = true;
+          if (currentStatus === 2 && targetStatus === 0) isAllowed = false; // In Progress -> Backlog
+          if (currentStatus === 1 && [0, 2].includes(targetStatus)) isAllowed = false; // Completed -> Backlog/In Progress
+          if (currentStatus === 0 && targetStatus === 1) isAllowed = false; // Backlog -> Completed
+          
+          if (!isAllowed) {
+            e.dataTransfer.dropEffect = 'none';
+            col.classList.add('drop-forbidden');
+            return;
+          }
+          
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'move';
+          col.classList.add('drop-hover');
+        });
+        col.addEventListener('dragleave', () => {
+          col.classList.remove('drop-hover');
+          col.classList.remove('drop-forbidden');
+        });
+        col.addEventListener('drop', async e => {
+          e.preventDefault();
+          col.classList.remove('drop-hover');
+          const id = draggedId || e.dataTransfer.getData('text/plain');
+          if (!id) return;
+          const status = parseInt(col.getAttribute('data-column-status'), 10);
+          // CSRF
+          const csrfParam = document.querySelector('meta[name="csrf-param"]');
+          const csrfToken = document.querySelector('meta[name="csrf-token"]');
+          const formData = new URLSearchParams();
+          formData.set('id', String(id));
+          formData.set('status', String(status));
+          if (csrfParam && csrfToken) {
+            formData.set(csrfParam.getAttribute('content'), csrfToken.getAttribute('content'));
+          }
+          try {
+            const resp = await fetch(moveTodoUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+              body: formData.toString(),
+              credentials: 'same-origin'
+            });
+            const data = await resp.json();
+            if (data && data.ok) {
+              // Optimistic UI: move the card DOM into the new column
+              const cardEl = document.querySelector('.card[draggable][data-todo-id="'+id+'"]');
+              const columnBody = col.querySelector('.board-header') ? col : col; // insert under the column
+              if (cardEl && columnBody) {
+                columnBody.appendChild(cardEl.parentElement && cardEl.parentElement.classList.contains('card') ? cardEl.parentElement : cardEl);
+              }
+              // Reload to reflect counts and badges quickly
+              window.location.reload();
+            } else {
+              console.error('Move failed', data);
+            }
+          } catch(err) {
+            console.error('Move error', err);
+          }
+        });
+      });
+    })();
     JS);
 ?>
 

--- a/views/site/index.php
+++ b/views/site/index.php
@@ -41,9 +41,12 @@ $this->title = 'Home';
 
 <hr>
 
-<div class="row g-4">
+<div class="row g-4 board-columns">
   <div class="col-md-4">
-    <h4>Backlog</h4>
+    <div class="board-header d-flex justify-content-between align-items-center mb-2">
+      <h4 class="mb-0">Backlog</h4>
+      <span class="badge rounded-pill bg-secondary"><?= isset($backlog) ? count($backlog) : 0 ?></span>
+    </div>
     <?php if (empty($backlog)): ?>
       <p class="text-muted">No items.</p>
     <?php else:
@@ -56,6 +59,13 @@ $this->title = 'Home';
                 'class' => 'btn btn-sm btn-outline-primary',
                 'data-method' => 'post'
             ]) ?>
+            <?= \yii\helpers\Html::a('Delete', ['site/delete', 'id' => $t->id], [
+                'class' => 'btn btn-sm btn-outline-danger ms-2',
+                'data' => [
+                    'confirm' => 'Delete this todo?',
+                    'method' => 'post',
+                ],
+            ]) ?>
           </div>
           <?php if ($t->description): ?>
             <div class="mt-2 text-muted"><?= nl2br(\yii\helpers\Html::encode($t->description)) ?></div>
@@ -67,7 +77,10 @@ endif; ?>
   </div>
 
   <div class="col-md-4">
-    <h4>In Progress</h4>
+    <div class="board-header d-flex justify-content-between align-items-center mb-2">
+      <h4 class="mb-0">In Progress</h4>
+      <span class="badge rounded-pill bg-warning text-dark"><?= isset($inProgress) ? count($inProgress) : 0 ?></span>
+    </div>
     <?php if (empty($inProgress)): ?>
       <p class="text-muted">No items.</p>
     <?php else:
@@ -79,6 +92,13 @@ endif; ?>
             <?= \yii\helpers\Html::a('Complete', ['site/complete-todo', 'id' => $t->id], [
                 'class' => 'btn btn-sm btn-success',
                 'data-method' => 'post'
+            ]) ?>
+            <?= \yii\helpers\Html::a('Delete', ['site/delete', 'id' => $t->id], [
+                'class' => 'btn btn-sm btn-outline-danger ms-2',
+                'data' => [
+                    'confirm' => 'Delete this todo?',
+                    'method' => 'post',
+                ],
             ]) ?>
           </div>
           <?php if ($t->description): ?>
@@ -96,7 +116,10 @@ endif; ?>
   </div>
 
   <div class="col-md-4">
-    <h4>Completed</h4>
+    <div class="board-header d-flex justify-content-between align-items-center mb-2">
+      <h4 class="mb-0">Completed</h4>
+      <span class="badge rounded-pill bg-success"><?= isset($completed) ? count($completed) : 0 ?></span>
+    </div>
     <?php if (empty($completed)): ?>
       <p class="text-muted">No items.</p>
     <?php else:
@@ -113,6 +136,15 @@ endif; ?>
         ?>
           <div class="mt-2">
             <small class="text-success">Took: <?= $elapsedText ?></small>
+          </div>
+          <div class="mt-2 text-end">
+            <?= \yii\helpers\Html::a('Delete', ['site/delete', 'id' => $t->id], [
+                'class' => 'btn btn-sm btn-outline-danger',
+                'data' => [
+                    'confirm' => 'Delete this todo?',
+                    'method' => 'post',
+                ],
+            ]) ?>
           </div>
         </div>
       </div>

--- a/views/site/index.php
+++ b/views/site/index.php
@@ -10,62 +10,151 @@ $this->title = 'Home';
 ?>
 
 <h1>Your Todos</h1>
+<p>
+    <?= \yii\helpers\Html::button('Add Todo', [
+        'class' => 'btn btn-primary',
+        'data-bs-toggle' => 'modal',
+        'data-bs-target' => '#addTodoModal'
+    ]) ?>
+</p>
 
-<?php $form = ActiveForm::begin(); ?>
-<?= $form->field($model, 'title')->textInput(['maxlength' => true, 'required' => true]) ?>
-<?= $form->field($model, 'description')->textarea(['rows' => 3]) ?>
-<div class="form-group">
-    <?= Html::submitButton('Add Todo', ['class' => 'btn btn-primary']) ?>
+<div class="modal fade" id="addTodoModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">New Todo</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <?php $form = \yii\widgets\ActiveForm::begin(); ?>
+            <?= $form->field($model, 'title')->textInput(['maxlength' => true, 'required' => true]) ?>
+            <?= $form->field($model, 'description')->textarea(['rows' => 3]) ?>
+      </div>
+      <div class="modal-footer">
+        <?= \yii\helpers\Html::submitButton('Create', ['class' => 'btn btn-primary']) ?>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+      </div>
+        <?php \yii\widgets\ActiveForm::end(); ?>
+    </div>
+  </div>
 </div>
-<?php ActiveForm::end(); ?>
 
 <hr>
 
-<?php if (empty($todos)): ?>
-    <p>Not Todos yet.</p>
-<?php else: ?>
-    <ul>
-        <?php foreach ($todos as $t): ?>
-            <li>
-                <strong><?= Html::encode($t->title) ?></strong>
-                <?php if ($t->description): ?>
-                    <div><?= nl2br(Html::encode($t->description)) ?></div>
-                <?php endif; ?>
-                <small>Status: <?= Html::encode($t->getStatusLabel()) ?></small>
+<div class="row g-4">
+  <div class="col-md-4">
+    <h4>Backlog</h4>
+    <?php if (empty($backlog)): ?>
+      <p class="text-muted">No items.</p>
+    <?php else:
+    foreach ($backlog as $t): ?>
+      <div class="card mb-3 shadow-sm">
+        <div class="card-body">
+          <div class="d-flex justify-content-between">
+            <strong><?= \yii\helpers\Html::encode($t->title) ?></strong>
+            <?= \yii\helpers\Html::a('Start', ['site/start-todo', 'id' => $t->id], [
+                'class' => 'btn btn-sm btn-outline-primary',
+                'data-method' => 'post'
+            ]) ?>
+          </div>
+          <?php if ($t->description): ?>
+            <div class="mt-2 text-muted"><?= nl2br(\yii\helpers\Html::encode($t->description)) ?></div>
+          <?php endif; ?>
+        </div>
+      </div>
+    <?php endforeach;
+endif; ?>
+  </div>
 
-                <div style="margin-top: 6px;">
-                    <?php if ((int) $t->status === \app\models\Todo::STATUS_PENDING): ?>
-                        <?= Html::a(
-                            'Mark as Done',
-                            ['site/toggle-todo', 'id' => $t->id],
-                            ['class' => 'btn btn-success btn-sm', 'data-method' => 'post']
-                        ) ?>
-                    <?php endif; ?>
-                    <?= Html::a(
-                        'Edit',
-                        ['site/index', 'edit_id' => $t->id],
-                        ['class' => 'btn btn-secondary btn-sm']
-                    ) ?>
-                </div>
+  <div class="col-md-4">
+    <h4>In Progress</h4>
+    <?php if (empty($inProgress)): ?>
+      <p class="text-muted">No items.</p>
+    <?php else:
+    foreach ($inProgress as $t): ?>
+      <div class="card mb-3 border-warning shadow-sm">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-center">
+            <strong><?= \yii\helpers\Html::encode($t->title) ?></strong>
+            <?= \yii\helpers\Html::a('Complete', ['site/complete-todo', 'id' => $t->id], [
+                'class' => 'btn btn-sm btn-success',
+                'data-method' => 'post'
+            ]) ?>
+          </div>
+          <?php if ($t->description): ?>
+            <div class="mt-2 text-muted"><?= nl2br(\yii\helpers\Html::encode($t->description)) ?></div>
+          <?php endif; ?>
+          <div class="mt-2">
+            <small class="text-warning">
+              Time spent: <span class="todo-timer" data-started-at="<?= (int) $t->started_at ?>"></span>
+            </small>
+          </div>
+        </div>
+      </div>
+    <?php endforeach;
+endif; ?>
+  </div>
 
-                <?php if ((int) Yii::$app->request->get('edit_id') === (int) $t->id): ?>
-                    <div style="margin-top: 10px;">
-                        <?php $form = ActiveForm::begin([
-                            'action' => ['site/update-todo', 'id' => $t->id],
-                            'method' => 'post',
-                        ]); ?>
-                        <?= $form->field($t, 'title')->textInput(['maxlength' => true, 'required' => true]) ?>
-                        <?= $form->field($t, 'description')->textarea(['rows' => 3]) ?>
-                        <div class="form-group">
-                            <?= Html::submitButton('Save', ['class' => 'btn btn-primary btn-sm']) ?>
-                            <?= Html::a('Cancel', ['site/index'], ['class' => 'btn btn-link btn-sm']) ?>
-                        </div>
-                        <?php ActiveForm::end(); ?>
-                    </div>
-                <?php endif; ?>
+  <div class="col-md-4">
+    <h4>Completed</h4>
+    <?php if (empty($completed)): ?>
+      <p class="text-muted">No items.</p>
+    <?php else:
+    foreach ($completed as $t): ?>
+      <div class="card mb-3 border-success shadow-sm">
+        <div class="card-body">
+          <strong><?= \yii\helpers\Html::encode($t->title) ?></strong>
+          <?php if ($t->description): ?>
+            <div class="mt-2 text-muted"><?= nl2br(\yii\helpers\Html::encode($t->description)) ?></div>
+          <?php endif; ?>
+          <?php
+        $elapsed = ($t->started_at && $t->completed_at) ? max(0, $t->completed_at - $t->started_at) : null;
+        $elapsedText = $elapsed !== null ? gmdate('H:i:s', $elapsed) : '—';
+        ?>
+          <div class="mt-2">
+            <small class="text-success">Took: <?= $elapsedText ?></small>
+          </div>
+        </div>
+      </div>
+    <?php endforeach;
+endif; ?>
+  </div>
+</div>
 
-                <hr>
-            </li>
-        <?php endforeach; ?>
-    </ul>
-<?php endif; ?>
+<?php
+$this->registerJs(<<<'JS'
+    function formatDuration(totalSeconds){
+      totalSeconds = Math.max(0, parseInt(totalSeconds || 0, 10));
+      const h = Math.floor(totalSeconds / 3600);
+      const m = Math.floor((totalSeconds % 3600) / 60);
+      const s = totalSeconds % 60;
+      const pad = n => n.toString().padStart(2,'0');
+      return `${pad(h)}:${pad(m)}:${pad(s)}`;
+    }
+
+    function startStopwatch(el, startedAt){
+      function update(){
+        const now = Math.floor(Date.now() / 1000);
+        const elapsed = now - startedAt;
+        el.textContent = formatDuration(elapsed);
+      }
+      update();
+      setInterval(update, 1000);
+    }
+
+    document.querySelectorAll('.todo-timer[data-started-at]').forEach(el => {
+      let startedAt = parseInt(el.getAttribute('data-started-at'), 10);
+      if (!isNaN(startedAt) && startedAt > 0) {
+        // normalize ms → seconds if needed
+        if (startedAt > 9999999999) {
+          startedAt = Math.floor(startedAt / 1000);
+        }
+        startStopwatch(el, startedAt);
+      } else {
+        el.textContent = "00:00:00"; // not started yet
+      }
+    });
+    JS);
+?>
+
+

--- a/web/css/site.css
+++ b/web/css/site.css
@@ -146,6 +146,31 @@ html[data-theme="dark"] .card:hover {
     box-shadow: 0 .35rem 1rem rgba(0,0,0,.35);
 }
 
+/* Drag & Drop visuals */
+.card.dragging {
+    opacity: .6;
+}
+
+[data-column-status].drop-hover {
+    outline: 2px dashed rgba(0,0,0,.25);
+    outline-offset: 6px;
+    border-radius: 8px;
+}
+html[data-theme="dark"] [data-column-status].drop-hover {
+    outline-color: rgba(255,255,255,.35);
+}
+
+[data-column-status].drop-forbidden {
+    outline: 2px dashed rgba(220,53,69,.6);
+    outline-offset: 6px;
+    border-radius: 8px;
+    background-color: rgba(220,53,69,.05);
+}
+html[data-theme="dark"] [data-column-status].drop-forbidden {
+    outline-color: rgba(255,107,107,.6);
+    background-color: rgba(255,107,107,.1);
+}
+
 /* THEME: dark overrides when html[data-theme="dark"] */
 html[data-theme="dark"] body {
     background-color: #121212;

--- a/web/css/site.css
+++ b/web/css/site.css
@@ -86,3 +86,141 @@ a.desc:after {
 .form-group {
     margin-bottom: 1rem;
 }
+
+/* UI polish */
+.board-header h4 { font-weight: 600; }
+
+.card {
+    transition: transform .12s ease, box-shadow .12s ease;
+}
+.card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 .25rem .75rem rgba(0,0,0,.08);
+}
+
+.badge.rounded-pill {
+    font-weight: 600;
+    letter-spacing: .02em;
+}
+
+body {
+    background-image: radial-gradient(ellipse at top left, rgba(0,0,0,0.03), transparent 40%),
+                      radial-gradient(ellipse at bottom right, rgba(0,0,0,0.03), transparent 40%);
+    background-attachment: fixed;
+}
+
+.card .card-body strong { font-weight: 600; }
+.card .mt-2 small { opacity: .9; }
+
+/* spacing tighten */
+.card.mb-3 { margin-bottom: 1rem !important; }
+.row.g-4 { row-gap: 1.25rem; }
+
+/* Column separators */
+.board-columns > [class^="col-"] {
+    position: relative;
+}
+.board-columns > [class^="col-"] + [class^="col-"]::before {
+    content: "";
+    position: absolute;
+    left: -12px;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: rgba(0,0,0,.08);
+}
+@media (max-width: 767.98px) {
+    .board-columns > [class^="col-"] + [class^="col-"]::before { display:none; }
+}
+
+html[data-theme="dark"] .board-columns > [class^="col-"] + [class^="col-"]::before {
+    background: rgba(255,255,255,.12);
+}
+
+/* Dark theme polish */
+html[data-theme="dark"] body {
+    background-image: radial-gradient(ellipse at top left, rgba(255,255,255,0.04), transparent 40%),
+                      radial-gradient(ellipse at bottom right, rgba(255,255,255,0.03), transparent 40%);
+}
+html[data-theme="dark"] .card:hover {
+    box-shadow: 0 .35rem 1rem rgba(0,0,0,.35);
+}
+
+/* THEME: dark overrides when html[data-theme="dark"] */
+html[data-theme="dark"] body {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+
+html[data-theme="dark"] .navbar-dark.bg-dark {
+    background-color: #0f0f0f !important;
+}
+
+html[data-theme="dark"] .card {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+    border-color: #2a2a2a;
+}
+
+html[data-theme="dark"] .text-muted { color: #b0b0b0 !important; }
+html[data-theme="dark"] .text-warning { color: #ffc107 !important; }
+html[data-theme="dark"] .text-success { color: #28a745 !important; }
+
+html[data-theme="dark"] .btn-outline-primary { color: #9ecbff; border-color: #9ecbff; }
+html[data-theme="dark"] .btn-outline-danger { color: #ff9ea3; border-color: #ff9ea3; }
+
+html[data-theme="dark"] .btn-outline-primary:hover { background-color: rgba(158,203,255,.1); }
+html[data-theme="dark"] .btn-outline-danger:hover { background-color: rgba(255,158,163,.1); }
+
+html[data-theme="dark"] .bg-light { background-color: #161616 !important; }
+html[data-theme="dark"] footer#footer { background-color: #161616 !important; color: #bdbdbd; }
+
+html[data-theme="dark"] a { color: #82b1ff; }
+html[data-theme="dark"] a:hover { color: #b3d1ff; }
+
+html[data-theme="dark"] .alert { background-color: #1b1b1b; border-color: #333; color: #ddd; }
+
+/* Dark theme: modal and form controls */
+html[data-theme="dark"] .modal-content {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+    border-color: #2a2a2a;
+}
+html[data-theme="dark"] .modal-header,
+html[data-theme="dark"] .modal-footer {
+    border-color: #2a2a2a;
+}
+html[data-theme="dark"] .modal-title { color: #e0e0e0; }
+
+html[data-theme="dark"] .form-label {
+    color: #e0e0e0;
+}
+html[data-theme="dark"] .form-control,
+html[data-theme="dark"] textarea.form-control {
+    background-color: #141414;
+    color: #e6e6e6;
+    border-color: #3a3a3a;
+}
+html[data-theme="dark"] .form-control:focus,
+html[data-theme="dark"] textarea.form-control:focus {
+    background-color: #161616;
+    color: #ffffff;
+    border-color: #5c9cff;
+    box-shadow: 0 0 0 0.2rem rgba(92,156,255,0.25);
+}
+html[data-theme="dark"] .form-control::placeholder,
+html[data-theme="dark"] textarea.form-control::placeholder {
+    color: #9aa0a6;
+}
+
+/* Validation states */
+html[data-theme="dark"] .invalid-feedback,
+html[data-theme="dark"] .error-summary,
+html[data-theme="dark"] .help-block,
+html[data-theme="dark"] .hint-block {
+    color: #ffb3b8;
+}
+html[data-theme="dark"] .error-summary {
+    background: #2a1e1f;
+    border-left-color: #b5545a;
+}


### PR DESCRIPTION
**Summary**
   Add a 3‑column board (Backlog, In Progress, Completed) and a per‑todo timer.
**Changes**
   DB: add started_at, completed_at (int, nullable).
   Model: add STATUS_IN_PROGRESS (2) and elapsed helper.
   Query: add inProgress() scope.
   Controller: start-todo, complete-todo actions; index loads three lists.
   View: modal “Add Todo”, 3 columns, live timer (JS), show “Took: HH:MM:SS” on completed.
**How it works**
   Start sets status=IN_PROGRESS and started_at; timer runs client‑side.
   Complete sets status=DONE and completed_at; duration persists.
**Test**
   1) Add a todo → shows in Backlog.
   2) Start → moves to In Progress, timer counts.
   3) Complete → moves to Completed with total time shown.
<img width="1374" height="311" alt="Screenshot from 2025-08-21 16-08-52" src="https://github.com/user-attachments/assets/98c9dbf6-3581-4093-964b-129b3577cc10" />
